### PR TITLE
Remove requirement of no spaces before object operator ->

### DIFF
--- a/DWS/ruleset.xml
+++ b/DWS/ruleset.xml
@@ -61,7 +61,6 @@
     <rule ref="Generic.WhiteSpace.DisallowTabIndent" />
     <rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace" />
     <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing" />
-    <rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing" />
     <rule ref="PEAR.WhiteSpace.ScopeClosingBrace" />
     <rule ref="Generic.WhiteSpace.ScopeIndent" />
     <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing" />


### PR DESCRIPTION
This commit removes the line from the ruleset requiring a space to
come before the arrow object operator ->. PSR2 does not enforce this
rule, and removing this rule will allow cleaner code when dealing
with fluent interfaces and method chaining. For example:

$obj->method1()
  ->method2()
  ->method3();

or

$obj
  ->method1()
  ->method2()
  ->method3();

This is especially useful when setting up PHPUnit mocks and their
constraints.

#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated