### PR TITLE
Fix absoluteNestingLevel property name

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/DWS/ruleset.xml
+++ b/DWS/ruleset.xml
@@ -42,7 +42,7 @@
     <rule ref="Generic.Metrics.NestingLevel">
         <properties>
             <property name="nestingLevel" value="3" />
-            <property name="absolutenestingLevel" value="5" />
+            <property name="absoluteNestingLevel" value="5" />
         </properties>
     </rule>
     <rule ref="Generic.NamingConventions.ConstructorName" />


### PR DESCRIPTION
#### What does this PR do?
Fixes the absoluteNestingLevel property name to be correctly cased. A change in PHPCS 3.8.0 required this to match exactly.

#### Checklist
- [x] Pull request contains a clear definition of changes
- [x] Tests (either unit, integration, or acceptance) written and passing
- [x] Relevant documentation produced and/or updated
